### PR TITLE
Fix typo in instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Following crypto addresses are supported:
 Install with pip:
 
 ```bash
-pip install faker-cypto
+pip install faker-crypto
 ```
 
 ## Usage


### PR DESCRIPTION
Corrected a typo error in the installation instruction within the `README.md` file. The error is an omission of the 'r' in 'crypto', resulting in installation issues as shown in the screenshot below.

<img width="706" alt="Screenshot 2024-02-02 at 6 09 10 PM" src="https://github.com/karambir/faker-crypto/assets/47994600/9e99e65a-14d1-4484-9086-62a96d6f08db">
